### PR TITLE
[squid:S2095] Resources should be closed

### DIFF
--- a/MultiSystem/src/com/hsbadr/MultiSystem/helpers/CPUHelper.java
+++ b/MultiSystem/src/com/hsbadr/MultiSystem/helpers/CPUHelper.java
@@ -168,19 +168,27 @@ public class CPUHelper {
     }
 
     public static boolean writeOneLine(String fname, String value) {
+        boolean succeeded = true;
+        FileWriter fw = null;
         try {
-            FileWriter fw = new FileWriter(fname);
-            try {
-                fw.write(value);
-            } finally {
-                fw.close();
-            }
+            fw = new FileWriter(fname);
+            fw.write(value);
+            
         } catch (IOException e) {
             String Error = "Error writing to " + fname + ". Exception: ";
             Log.e(TAG, Error, e);
-            return false;
+            succeeded = false;
+        } finally {
+            try {
+                if (fw != null)
+                    fw.close();
+            } catch (IOException e) {
+                String Error = "Error writing to " + fname + ". Exception: ";
+                Log.e(TAG, Error, e);
+                succeeded = false;
+            }
         }
-        return true;
+        return succeeded;
     }
 
     public static String[] getAvailableIOSchedulers() {

--- a/libs/CardsUILib/src/com/fima/cardsui/views/CardDownload.java
+++ b/libs/CardsUILib/src/com/fima/cardsui/views/CardDownload.java
@@ -101,14 +101,16 @@ public class CardDownload extends Card {
         @Override
         protected String doInBackground(String... f_url) {
             int count;
+            InputStream input = null;
+            OutputStream output = null;
             try {
                 URL url = new URL(f_url[0]);
                 URLConnection connection = url.openConnection();
                 connection.connect();
 
                 int lengthOfFile = connection.getContentLength();
-                InputStream input = new BufferedInputStream(url.openStream(), 8192);
-                OutputStream output = new FileOutputStream(f_url[1]);
+                input = new BufferedInputStream(url.openStream(), 8192);
+                output = new FileOutputStream(f_url[1]);
 
                 byte data[] = new byte[1024];
                 long total = 0;
@@ -119,10 +121,22 @@ public class CardDownload extends Card {
                     output.write(data, 0, count);
                 }
                 output.flush();
-                output.close();
-                input.close();
             } catch (Exception e) {
                 Log.e("Error: ", e.getMessage());
+            } finally {
+                try {
+                    if (output != null)
+                        output.close();
+                } catch (Exception e) {
+                    Log.e("Error: ", e.getMessage()); 
+                }
+
+                try {
+                    if (input != null)
+                        input.close();
+                } catch (Exception e) {
+                    Log.e("Error: ", e.getMessage());
+                }
             }
             return null;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Abdelghany.