### PR TITLE
[squid:S2131] Primitives should not be boxed just for "String" conversion

### DIFF
--- a/MultiSystem/src/com/hsbadr/MultiSystem/cards/CardSeekBarCombo.java
+++ b/MultiSystem/src/com/hsbadr/MultiSystem/cards/CardSeekBarCombo.java
@@ -69,7 +69,7 @@ public class CardSeekBarCombo extends Card {
 
             @Override
             public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
-                e.setText(i + "");
+                e.setText(Integer.toString(i));
                 seekBarProgress = i;
             }
 

--- a/MultiSystem/src/com/hsbadr/MultiSystem/fragments/PluginFragment.java
+++ b/MultiSystem/src/com/hsbadr/MultiSystem/fragments/PluginFragment.java
@@ -404,7 +404,7 @@ public class PluginFragment extends Fragment implements ParserInterface {
                                 runSuCommand(Shell.SED + prop + "/d\" " + Shell.BUILD_PROP);
                                 runSuCommand(Shell.ECHO + "\"" + prop + "=" + value + "\" >> " + Shell.BUILD_PROP);
                                 runSuCommand("setprop " + prop + " " + value);
-                                SystemPropertiesReflection.set(fa, prop, value + "");
+                                SystemPropertiesReflection.set(fa, prop, Integer.toString(value));
                                 SharedPreferences pref = fa.getSharedPreferences(title, 0);
                                 pref.edit().putInt(title, value).commit();
                             } catch (NullPointerException e) {

--- a/libs/CardsUILib/src/com/fima/cardsui/views/CardDownload.java
+++ b/libs/CardsUILib/src/com/fima/cardsui/views/CardDownload.java
@@ -101,28 +101,42 @@ public class CardDownload extends Card {
         @Override
         protected String doInBackground(String... f_url) {
             int count;
+            InputStream input = null;
+            OutputStream output = null;
             try {
                 URL url = new URL(f_url[0]);
                 URLConnection connection = url.openConnection();
                 connection.connect();
 
                 int lengthOfFile = connection.getContentLength();
-                InputStream input = new BufferedInputStream(url.openStream(), 8192);
-                OutputStream output = new FileOutputStream(f_url[1]);
+                input = new BufferedInputStream(url.openStream(), 8192);
+                output = new FileOutputStream(f_url[1]);
 
                 byte data[] = new byte[1024];
                 long total = 0;
 
                 while ((count = input.read(data)) != -1) {
                     total += count;
-                    publishProgress("" + (int) ((total * 100) / lengthOfFile));
+                    publishProgress(Integer.toString((int) ((total * 100) / lengthOfFile)));
                     output.write(data, 0, count);
                 }
                 output.flush();
-                output.close();
-                input.close();
             } catch (Exception e) {
                 Log.e("Error: ", e.getMessage());
+            } finally {
+                try {
+                    if (output != null)
+                        output.close();
+                } catch (Exception e) {
+                    Log.e("Error: ", e.getMessage()); 
+                }
+
+                try {
+                    if (input != null)
+                        input.close();
+                } catch (Exception e) {
+                    Log.e("Error: ", e.getMessage());
+                }
             }
             return null;
         }

--- a/libs/HoloGraphLibrary/src/com/echo/holographlibrary/LineGraph.java
+++ b/libs/HoloGraphLibrary/src/com/echo/holographlibrary/LineGraph.java
@@ -185,8 +185,8 @@ public class LineGraph extends View {
 		if (fullImage == null || shouldUpdate) {
 			fullImage = Bitmap.createBitmap(getWidth(), getHeight(), Config.ARGB_8888);
 			Canvas canvas = new Canvas(fullImage);
-			String max = (int)maxY+"";// used to display max
-			String min = (int)minY+"";// used to display min
+			String max = Integer.toString((int)maxY);// used to display max
+			String min = Integer.toString((int)minY);// used to display min
 			paint.reset();
 			Path path = new Path();
 			


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.
Ayman Abdelghany.